### PR TITLE
find_urls and index url '/'

### DIFF
--- a/fancy_cache/memory.py
+++ b/fancy_cache/memory.py
@@ -21,10 +21,10 @@ def _urls_to_regexes(urls):
     for each in urls:
         parts = each.split('*')
         if len(parts) == 1:
-            regexes.append(re.compile(re.escape(parts[0])))
+            regexes.append(re.compile('^%s$' % re.escape(parts[0])))
         else:
             _re = '.*'.join(re.escape(x) for x in parts)
-            regexes.append(re.compile(_re))
+            regexes.append(re.compile('^%s$' % _re))
     return regexes
 
 


### PR DESCRIPTION
find_urls looking cached urls as occurrence of a substring, so you can't use this function to find index url '/', because find_urls returns all urls ('/' is a substring for all cached urls)
