### PR TITLE
Adds cache argument to cache_page decorator

### DIFF
--- a/docs/gettingfancy.rst
+++ b/docs/gettingfancy.rst
@@ -92,7 +92,7 @@ new comment is posted, the page is immediately refreshed.
 
 As soon as you've implemented something like this and you get
 confident that your ``key_prefix`` callable is good you can start
-increasnig the timeout from one hour to one week or something like
+increasing the timeout from one hour to one week or something like
 that.
 
 Another realistic use case of this is if your logged-in users get
@@ -149,9 +149,9 @@ new comment is added::
         post_pk = instance.post.pk
         post_url = reverse('blog:post', args=(post_pk,))
         list(find_urls([post_url], purge=True))
- 
+
 Note: Since find_urls() returns a generator, the purging won't happen unless you exhaust the generator.
-E.g. looping over it or turning it into a list. 
+E.g. looping over it or turning it into a list.
 
 Voila! As soon as a new comment is added to a post, all cached URLs
 with that URL are purged from the cache.

--- a/fancy_cache/cache_page.py
+++ b/fancy_cache/cache_page.py
@@ -4,7 +4,8 @@ from .middleware import CacheMiddleware
 
 
 def cache_page(*args, **kwargs):
+    cache_alias = kwargs.pop('cache', None)
     return (
         decorator_from_middleware_with_args
-        (CacheMiddleware)(*args, **kwargs)
+        (CacheMiddleware)(cache_alias=cache_alias, *args, **kwargs)
     )

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -3,7 +3,7 @@ import functools
 
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import cache, DEFAULT_CACHE_ALIAS
 from django.utils.encoding import iri_to_uri
 from django.utils.cache import (
     get_cache_key,
@@ -290,30 +290,32 @@ class CacheMiddleware(UpdateCacheMiddleware, FetchFromCacheMiddleware):
         of the number of times a `cache_page` hits and misses.
 
     """
-    def __init__(self,
-                 cache_timeout=settings.CACHE_MIDDLEWARE_SECONDS,
-                 key_prefix=settings.CACHE_MIDDLEWARE_KEY_PREFIX,
-                 cache_anonymous_only=getattr(
-                     settings,
-                     'CACHE_MIDDLEWARE_ANONYMOUS_ONLY',
-                     False
-                 ),
-                 patch_headers=False,
-                 post_process_response=None,
-                 post_process_response_always=None,
-                 only_get_keys=None,
-                 forget_get_keys=None,
-                 remember_all_urls=getattr(
-                     settings,
-                     'FANCY_REMEMBER_ALL_URLS',
-                     False
-                 ),
-                 remember_stats_all_urls=getattr(
-                     settings,
-                     'FANCY_REMEMBER_STATS_ALL_URLS',
-                     False
-                 ),
-                 ):
+    def __init__(
+        self,
+        cache_timeout=settings.CACHE_MIDDLEWARE_SECONDS,
+        key_prefix=settings.CACHE_MIDDLEWARE_KEY_PREFIX,
+        cache_anonymous_only=getattr(
+            settings,
+            'CACHE_MIDDLEWARE_ANONYMOUS_ONLY',
+            False
+        ),
+        patch_headers=False,
+        post_process_response=None,
+        post_process_response_always=None,
+        only_get_keys=None,
+        forget_get_keys=None,
+        remember_all_urls=getattr(
+            settings,
+            'FANCY_REMEMBER_ALL_URLS',
+            False
+        ),
+        remember_stats_all_urls=getattr(
+            settings,
+            'FANCY_REMEMBER_STATS_ALL_URLS',
+            False
+        ),
+        **kwargs
+    ):
         self.patch_headers = patch_headers
         self.cache_timeout = cache_timeout
         self.key_prefix = key_prefix
@@ -328,3 +330,12 @@ class CacheMiddleware(UpdateCacheMiddleware, FetchFromCacheMiddleware):
         self.forget_get_keys = forget_get_keys
         self.remember_all_urls = remember_all_urls
         self.remember_stats_all_urls = remember_stats_all_urls
+
+        try:
+            cache_alias = kwargs['cache_alias']
+            if cache_alias is None:
+                cache_alias = DEFAULT_CACHE_ALIAS
+        except KeyError:
+            cache_alias = settings.CACHE_MIDDLEWARE_ALIAS
+
+        self.cache_alias = cache_alias


### PR DESCRIPTION
This adds the `cache` arg to the `@cache_page` decorator

https://docs.djangoproject.com/en/1.9/topics/cache/

> cache_page can also take an optional keyword argument, cache, which directs the decorator to use a specific cache (from your CACHES setting) when caching view results. By default, the default cache will be used, but you can specify any cache you want:

I'd assume some tests need updating/adding for this but I couldn't get them running on my machine.