### PR TITLE
Python 3 fix "AttributeError: 'str' object has no attribute 'decode'"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,13 @@ from setuptools import setup, find_packages
 
 
 def read(*parts):
-    return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read().decode("utf8")
-
+    content = codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read()
+    try:
+        return content.decode("utf8")
+    except AttributeError:
+        # python 3
+        return content
+    
 
 def find_version(*file_paths):
     version_file = read(*file_paths)


### PR DESCRIPTION
This is a fix for pip installing with python 3

```
Collecting django-fancy-cache==0.8.0 (from -r requirements.txt (line 54))
  Using cached django-fancy-cache-0.8.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-hzvye37e/django-fancy-cache/setup.py", line 31, in <module>
        version=find_version('fancy_cache/__init__.py'),
      File "/tmp/pip-build-hzvye37e/django-fancy-cache/setup.py", line 21, in find_version
        version_file = read(*file_paths)
      File "/tmp/pip-build-hzvye37e/django-fancy-cache/setup.py", line 17, in read
        return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read().decode("utf8")
    AttributeError: 'str' object has no attribute 'decode'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-hzvye37e/django-fancy-cache/
```