### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ python:
 env:
 - TOX_ENV=py27_dj18
 - TOX_ENV=py34_dj18
+- TOX_ENV=py35_dj18
 - TOX_ENV=py27_dj19
 - TOX_ENV=py34_dj19
+- TOX_ENV=py35_dj19
+- TOX_ENV=py27_dj110
+- TOX_ENV=py34_dj110
+- TOX_ENV=py35_dj110
+- TOX_ENV=py36_dj110
 install:
 - pip install tox wheel
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,10 @@ python:
 - "3.4"
 - "3.5"
 - "3.6"
-env:
-- TOX_ENV=py27_dj18
-- TOX_ENV=py34_dj18
-- TOX_ENV=py35_dj18
-- TOX_ENV=py27_dj19
-- TOX_ENV=py34_dj19
-- TOX_ENV=py35_dj19
-- TOX_ENV=py27_dj110
-- TOX_ENV=py34_dj110
-- TOX_ENV=py35_dj110
-- TOX_ENV=py36_dj110
 install:
-- pip install tox wheel
+- pip install tox-travis wheel
 script:
-- tox -e $TOX_ENV
+- tox
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: python
 python:
-- 2.7
+- "2.7"
+- "3.4"
+- "3.5"
+- "3.6"
 env:
 - TOX_ENV=py27_dj18
 - TOX_ENV=py34_dj18

--- a/fancy_cache/management/commands/fancy-urls.py
+++ b/fancy_cache/management/commands/fancy-urls.py
@@ -35,27 +35,24 @@ from fancy_cache.memory import find_urls
 class Command(BaseCommand):
     help = __doc__.strip()
 
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '-p', '--purge', dest='purge', action='store_true',
-            help='Purge found URLs'
-        ),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument('-p', '--purge', dest='purge', action='store_true',
+            help='Purge found URLs')
+
     args = 'urls'
 
     def handle(self, *urls, **options):
         verbose = int(options['verbosity']) > 1
-
         _count = 0
         for url, cache_key, stats in find_urls(urls, purge=options['purge']):
             _count += 1
             if stats:
-                print(url[:70].ljust(65)),
-                print("HITS", str(stats['hits']).ljust(5)),
-                print("MISSES", str(stats['misses']).ljust(5))
+                self.stdout.write(url[:70].ljust(65)),
+                self.stdout.write("HITS", str(stats['hits']).ljust(5)),
+                self.stdout.write("MISSES", str(stats['misses']).ljust(5))
 
             else:
-                print(url)
+                self.stdout.write(url)
 
         if verbose:
-            print("-- %s URLs cached --" % _count)
+            self.stdout.write("-- %s URLs cached --" % _count)

--- a/fancy_cache/urls.py
+++ b/fancy_cache/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
-
+from . import views
 
 
 urlpatterns = [
-    url(r'^$', 'fancy_cache.views.home', name='home'),
+    url(r'^$', views.home, name='home'),
 ]

--- a/fancy_tests/tests/test_command.py
+++ b/fancy_tests/tests/test_command.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from nose.tools import eq_, ok_
+from django.core.cache import cache
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.six import StringIO
+from fancy_cache.middleware import REMEMBERED_URLS_KEY
+
+
+class TestBaseCommand(TestCase):
+    def setUp(self):
+        self.urls = {
+            '/page1.html': 'key1',
+            '/page2.html': 'key2',
+            '/page3.html?foo=bar': 'key3',
+            '/page3.html?foo=else': 'key4',
+        }
+        for key, value in self.urls.items():
+            cache.set(value, key)
+        cache.set(REMEMBERED_URLS_KEY, self.urls, 5)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_fancyurls_command(self):
+        out = StringIO()
+        call_command('fancy-urls', verbosity=3, stdout=out)
+        self.assertIn('4 URLs cached', out.getvalue())
+
+    def test_purge_command(self):
+        out = StringIO()
+        # Note: first call will show 4 URLs, so call again to confirm deletion
+        call_command('fancy-urls', '--purge')
+        call_command('fancy-urls', verbosity=3, stdout=out)
+        self.assertIn('0 URLs cached', out.getvalue())

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     tests_require=['nose'],
     test_suite='runtests.runtests',

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27_dj18, py34_dj18, py35_dj18, py27_dj19, py34_dj19, py35_dj19
-
+envlist = py27_dj18,  py34_dj18,  py35_dj18, 
+          py27_dj19,  py34_dj19,  py35_dj19, 
+          py27_dj110, py34_dj110, py35_dj110, py36_dj110
 
 [testenv:py27_dj18]
 basepython = python2.7
@@ -30,21 +31,49 @@ commands = pip install --ignore-installed 'django>= 1.8, <1.9'
 
 [testenv:py27_dj19]
 basepython = python2.7
-commands = pip install --ignore-installed 'django>= 1.9, <2.0'
+commands = pip install --ignore-installed 'django>= 1.9, <1.10'
            pip install -r requirements.txt
            pip install mock
            {envpython} setup.py test
 
 [testenv:py34_dj19]
 basepython = python3.4
-commands = pip install --ignore-installed 'django>= 1.9, <2.0'
+commands = pip install --ignore-installed 'django>= 1.9, <1.10'
            pip install -r requirements.txt
            pip install mock
            {envpython} setup.py test
 
 [testenv:py35_dj19]
 basepython = python3.5
-commands = pip install --ignore-installed 'django>= 1.9, <2.0'
+commands = pip install --ignore-installed 'django>= 1.9, <1.10'
+          pip install -r requirements.txt
+          pip install mock
+          {envpython} setup.py test
+
+[testenv:py27_dj110]
+basepython = python2.7
+commands = pip install --ignore-installed 'django>= 1.10, <1.11'
+          pip install -r requirements.txt
+          pip install mock
+          {envpython} setup.py test
+
+[testenv:py34_dj110]
+basepython = python3.4
+commands = pip install --ignore-installed 'django>= 1.10, <1.11'
+          pip install -r requirements.txt
+          pip install mock
+          {envpython} setup.py test
+
+[testenv:py35_dj110]
+basepython = python3.5
+commands = pip install --ignore-installed 'django>= 1.10, <1.11'
+          pip install -r requirements.txt
+          pip install mock
+          {envpython} setup.py test
+
+[testenv:py36_dj110]
+basepython = python3.6
+commands = pip install --ignore-installed 'django>= 1.10, <1.11'
           pip install -r requirements.txt
           pip install mock
           {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,76 +4,24 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27_dj18,  py34_dj18,  py35_dj18, 
-          py27_dj19,  py34_dj19,  py35_dj19, 
-          py27_dj110, py34_dj110, py35_dj110, py36_dj110
+envlist = py27-dj{18,19,110},
+          py34-dj{18,19,110},
+          py35-dj{18,19,110},
+          py36-dj{110}
 
-[testenv:py27_dj18]
-basepython = python2.7
-commands = pip install --ignore-installed 'django>= 1.8, <1.9'
-           pip install -r requirements.txt
-           pip install mock
+[testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+deps =  
+    dj18: Django>=1.8,<1.9    
+    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10, <1.11
+    mock
+    
+usedevelop = true
+
+commands = pip install -r requirements.txt
            {envpython} setup.py test
-
-[testenv:py34_dj18]
-basepython = python3.4
-commands = pip install --ignore-installed 'django>= 1.8, <1.9'
-           pip install -r requirements.txt
-           pip install mock
-           {envpython} setup.py test
-
-[testenv:py35_dj18]
-basepython = python3.5
-commands = pip install --ignore-installed 'django>= 1.8, <1.9'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test
-
-[testenv:py27_dj19]
-basepython = python2.7
-commands = pip install --ignore-installed 'django>= 1.9, <1.10'
-           pip install -r requirements.txt
-           pip install mock
-           {envpython} setup.py test
-
-[testenv:py34_dj19]
-basepython = python3.4
-commands = pip install --ignore-installed 'django>= 1.9, <1.10'
-           pip install -r requirements.txt
-           pip install mock
-           {envpython} setup.py test
-
-[testenv:py35_dj19]
-basepython = python3.5
-commands = pip install --ignore-installed 'django>= 1.9, <1.10'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test
-
-[testenv:py27_dj110]
-basepython = python2.7
-commands = pip install --ignore-installed 'django>= 1.10, <1.11'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test
-
-[testenv:py34_dj110]
-basepython = python3.4
-commands = pip install --ignore-installed 'django>= 1.10, <1.11'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test
-
-[testenv:py35_dj110]
-basepython = python3.5
-commands = pip install --ignore-installed 'django>= 1.10, <1.11'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test
-
-[testenv:py36_dj110]
-basepython = python3.6
-commands = pip install --ignore-installed 'django>= 1.10, <1.11'
-          pip install -r requirements.txt
-          pip install mock
-          {envpython} setup.py test


### PR DESCRIPTION
Updated the` urls.py ` to be compatible with Django 1.10 and updated the Tox / Travis builds so that they were simple and all correct. Also added Python 3.6, since it's now supported by Django 1.10.