### PR TITLE
Use Memcached CAS to remember urls if available.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,7 @@ turning it into a list.
     # in settings.py
  
     FANCY_USE_MEMCACHED_CHECK_AND_SET = True
+
     CACHES = {
         'default': {
             'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,9 @@ If you want to you can have ``django-fancy-cache`` record every URL it
 caches. This can be useful for things like invalidation or curious
 statistical inspection.
 
+  
+
+
 You can either switch this on on the decorator itself. Like this:
 
 .. code:: python
@@ -117,6 +120,24 @@ option like this:
 Note: Since ``find_urls()`` returns a generator, the purging won't
 happen unless you exhaust the generator. E.g. looping over it or
 turning it into a list.
+
+> :warning: **If you are using Memcached, you must 
+> enable check-and-set to remember all urls**:
+
+.. code:: python
+   CACHES = {
+       'default': {
+           'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+           'LOCATION': '127.0.0.1:11211',
+           # This OPTIONS setting enables Memcached check-and-set which is
+           # required for remember_all_urls or FANCY_REMEMBER_ALL_URLS.
+           'OPTIONS': {  
+               'behaviors': {
+                   'cas': True
+               }
+           }
+       }
+    }
 
 The second way to inspect all recorded URLs is to use the
 ``fancy-cache`` management command. This is only available if you have

--- a/README.rst
+++ b/README.rst
@@ -119,22 +119,27 @@ happen unless you exhaust the generator. E.g. looping over it or
 turning it into a list.
 
 > :warning: **If you are using Memcached, you must 
-> enable check-and-set to remember all urls**:
+> enable check-and-set to remember all urls**
+> by enabling the `FANCY_USE_MEMCACHED_CHECK_AND_SET`
+> flag and enabling `cas` in your `CACHES` settings:
 
 .. code:: python
-   CACHES = {
-       'default': {
-           'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
-           'LOCATION': '127.0.0.1:11211',
-           # This OPTIONS setting enables Memcached check-and-set which is
-           # required for remember_all_urls or FANCY_REMEMBER_ALL_URLS.
-           'OPTIONS': {  
-               'behaviors': {
-                   'cas': True
-               }
-           }
-       }
-    }
+    # in settings.py
+ 
+    FANCY_USE_MEMCACHED_CHECK_AND_SET = True
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+            'LOCATION': '127.0.0.1:11211',
+            # This OPTIONS setting enables Memcached check-and-set which is
+            # required for remember_all_urls or FANCY_REMEMBER_ALL_URLS.
+            'OPTIONS': {  
+                'behaviors': {
+                    'cas': True
+                }
+            }
+        }
+     }
 
 The second way to inspect all recorded URLs is to use the
 ``fancy-cache`` management command. This is only available if you have

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,6 @@ If you want to you can have ``django-fancy-cache`` record every URL it
 caches. This can be useful for things like invalidation or curious
 statistical inspection.
 
-  
-
-
 You can either switch this on on the decorator itself. Like this:
 
 .. code:: python

--- a/docs/gettingfancy.rst
+++ b/docs/gettingfancy.rst
@@ -154,9 +154,14 @@ Note: Since find_urls() returns a generator, the purging won't happen unless you
 E.g. looping over it or turning it into a list.
 
 > :warning: **If you are using Memcached, you must 
-> enable check-and-set to remember all urls**:
+> enable check-and-set to remember all urls**
+> by enabling the `FANCY_USE_MEMCACHED_CHECK_AND_SET`
+> flag and enabling `cas` in your `CACHES` settings:
 
     # in settings.py
+
+    FANCY_USE_MEMCACHED_CHECK_AND_SET = True
+
     CACHES = {
         'default': {
             'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',

--- a/docs/gettingfancy.rst
+++ b/docs/gettingfancy.rst
@@ -171,7 +171,6 @@ E.g. looping over it or turning it into a list.
         }
     }
 
-
 Voila! As soon as a new comment is added to a post, all cached URLs
 with that URL are purged from the cache.
 

--- a/docs/gettingfancy.rst
+++ b/docs/gettingfancy.rst
@@ -153,6 +153,25 @@ new comment is added::
 Note: Since find_urls() returns a generator, the purging won't happen unless you exhaust the generator.
 E.g. looping over it or turning it into a list.
 
+> :warning: **If you are using Memcached, you must 
+> enable check-and-set to remember all urls**:
+
+    # in settings.py
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+            'LOCATION': '127.0.0.1:11211',
+            # This OPTIONS setting enables Memcached check-and-set which is
+            # required for remember_all_urls or FANCY_REMEMBER_ALL_URLS.
+            'OPTIONS': {  
+                'behaviors': {
+                    'cas': True
+                }
+            }
+        }
+    }
+
+
 Voila! As soon as a new comment is added to a post, all cached URLs
 with that URL are purged from the cache.
 

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -135,11 +135,8 @@ class UpdateCacheMiddleware(object):
         All cached URLs are remembered in a dictionary
         in the cache under REMEMBERED_URLS_KEY.
 
-        For most backends including Redis, self.cache.set will
-        successfully set the dictionary atomically in a thread-safe manner.
-
-        For Memcached, we try to use CAS (check and set) to set
-        the dictionary via self.cache._cache.cas to avoid missing
+        If USE_MEMCACHED_CAS is True, we try to use CAS (check and set)
+        to set the dictionary via self.cache._cache.cas to avoid missing
         cached URLs in high traffic environments.cache._cache.cas.
 
         See Issue #7 for more information:
@@ -155,6 +152,7 @@ class UpdateCacheMiddleware(object):
                 # Remembered URLs have been successfully saved
                 # via Memcached CAS.
                 return
+
         remembered_urls = self.cache.get(REMEMBERED_URLS_KEY, {})
         remembered_urls[url] = cache_key
         self.cache.set(REMEMBERED_URLS_KEY, remembered_urls, LONG_TIME)

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -123,18 +123,6 @@ class UpdateCacheMiddleware(object):
 
         return response
 
-    def _is_memcached_backend_with_check_and_set(self):
-        """
-        Helper function that returns True if the backend is Memcached
-        and the check-and-set API is available.
-
-        Returns False otherwise.
-        """
-        return (
-            hasattr(self.cache._cache, "cas") and
-            hasattr(self.cache._cache, "gets")
-        )
-
     def remember_url(self, request, cache_key, timeout):
         """
         Function to remember a newly cached URL.
@@ -153,11 +141,11 @@ class UpdateCacheMiddleware(object):
         https://github.com/peterbe/django-fancy-cache/issues/7
         """
         url = request.get_full_path()
-        if self._is_memcached_backend_with_check_and_set():
+        if settings.FANCY_USE_MEMCACHED_CHECK_AND_SET is True:
             # Memcached check-and-set is available.
             # Try using check-and-set to avoid a race condition
             # in remembering urls; if this fails, fallback to cache.set.
-            result = self.remember_url_cas(url, cache_key)
+            result = self._remember_url_cas(url, cache_key)
             if result:
                 # Remembered URLs have been successfully saved
                 # via Memcached CAS.

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -123,6 +123,18 @@ class UpdateCacheMiddleware(object):
 
         return response
 
+    def _is_memcached_backend_with_check_and_set(self):
+        """
+        Helper function that returns True if the backend is Memcached
+        and the check-and-set API is available.
+
+        Returns False otherwise.
+        """
+        return (
+            hasattr(self.cache._cache, "cas") and
+            hasattr(self.cache._cache, "gets")
+        )
+
     def remember_url(self, request, cache_key, timeout):
         """
         Function to remember a newly cached URL.

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -19,6 +19,11 @@ LOGGER = logging.getLogger(__name__)
 
 REMEMBERED_URLS_KEY = "fancy-urls"
 LONG_TIME = 60 * 60 * 24 * 30
+USE_MEMCACHED_CAS = getattr(
+    settings,
+    "FANCY_USE_MEMCACHED_CHECK_AND_SET",
+    False
+)
 
 
 class RequestPath(object):
@@ -141,7 +146,7 @@ class UpdateCacheMiddleware(object):
         https://github.com/peterbe/django-fancy-cache/issues/7
         """
         url = request.get_full_path()
-        if settings.FANCY_USE_MEMCACHED_CHECK_AND_SET is True:
+        if USE_MEMCACHED_CAS is True:
             # Memcached check-and-set is available.
             # Try using check-and-set to avoid a race condition
             # in remembering urls; if this fails, fallback to cache.set.


### PR DESCRIPTION
Fixes #7.

@peterbe thanks for considering this PR! I've done some research into the issue with Memcached race conditions and believe this will solve the problem using Memcached CAS ("check and set"). It's simpler than storing `remembered_urls` in the db.

I've implemented such that the code tries using Memcached CAS and falls back to the current functionality in the event of an `AttributeError` that shows that `cache.cas` is unavailable.

Please let me know if you have any thoughts or improvements. Thanks again for maintaining this great repo!