### PR TITLE
Feature/save n days of cache values

### DIFF
--- a/fancy_cache/constants.py
+++ b/fancy_cache/constants.py
@@ -1,0 +1,2 @@
+REMEMBERED_URLS_KEY = "fancy-urls"
+LONG_TIME = 60 * 60 * 24 * 30

--- a/fancy_cache/memory.py
+++ b/fancy_cache/memory.py
@@ -1,12 +1,19 @@
+import logging
 import re
+import typing
 
 from django.core.cache import cache
 
-from fancy_cache.middleware import REMEMBERED_URLS_KEY, LONG_TIME
+from fancy_cache.middleware import (
+    REMEMBERED_URLS_KEY,
+    LONG_TIME,
+    USE_MEMCACHED_CAS,
+)
 from fancy_cache.utils import md5
 
 __all__ = ("find_urls",)
 
+LOGGER = logging.getLogger(__name__)
 
 def _match(url, regexes):
     if not regexes:
@@ -31,7 +38,7 @@ def _urls_to_regexes(urls):
 
 def find_urls(urls=None, purge=False):
     remembered_urls = cache.get(REMEMBERED_URLS_KEY, {})
-    _del_keys = []
+    keys_to_delete = []
     if urls:
         regexes = _urls_to_regexes(urls)
     for url in remembered_urls:
@@ -41,7 +48,7 @@ def find_urls(urls=None, purge=False):
                 continue
             if purge:
                 cache.delete(cache_key)
-                _del_keys.append(url)
+                keys_to_delete.append(url)
             misses_cache_key = "%s__misses" % url
             misses_cache_key = md5(misses_cache_key)
             hits_cache_key = "%s__hits" % url
@@ -55,13 +62,46 @@ def find_urls(urls=None, purge=False):
                 stats = {"hits": hits or 0, "misses": misses or 0}
             yield (url, cache_key, stats)
 
-    if _del_keys:
+    if keys_to_delete:
         # means something was changed
-        for url in _del_keys:
-            remembered_urls.pop(url)
-            misses_cache_key = "%s__misses" % url
-            hits_cache_key = "%s__hits" % url
-            cache.delete(misses_cache_key)
-            cache.delete(hits_cache_key)
 
+        if USE_MEMCACHED_CAS is True:
+            deleted = delete_keys_cas(keys_to_delete)
+            if deleted is True:
+                return
+
+        remembered_urls = cache.get(REMEMBERED_URLS_KEY, {})
+        remembered_urls = delete_keys(keys_to_delete, remembered_urls)
         cache.set(REMEMBERED_URLS_KEY, remembered_urls, LONG_TIME)
+
+
+def delete_keys_cas(keys_to_delete: typing.List[str]) -> bool:
+    result = False
+    tries = 0
+    while result is False and tries < 100:
+        remembered_urls, cas_token = cache._cache.gets(REMEMBERED_URLS_KEY)
+        if remembered_urls is None:
+            return False
+        remembered_urls = delete_keys(keys_to_delete, remembered_urls)
+        result = cache._cache.cas(
+            REMEMBERED_URLS_KEY, remembered_urls, cas_token, LONG_TIME
+        )
+        tries += 1
+    if result is False:
+        LOGGER.error("Fancy cache delete_keys_cas failed after %s tries", tries)
+    return result
+
+
+def delete_keys(
+    keys_to_delete: typing.List[str], remembered_urls: typing.Dict[str, str]
+) -> typing.Dict[str, str]:
+    """
+    Helper function to delete `keys_to_delete` from the `remembered_urls` dict.
+    """
+    for url in keys_to_delete:
+        remembered_urls.pop(url)
+        misses_cache_key = "%s__misses" % url
+        hits_cache_key = "%s__hits" % url
+        cache.delete(misses_cache_key)
+        cache.delete(hits_cache_key)
+    return remembered_urls

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -177,10 +177,7 @@ class UpdateCacheMiddleware(object):
             remembered_urls[url] = cache_key
 
             result = self.cache._cache.cas(
-                REMEMBERED_URLS_KEY,
-                remembered_urls,
-                cas_token,
-                LONG_TIME
+                REMEMBERED_URLS_KEY, remembered_urls, cas_token, LONG_TIME
             )
 
             tries += 1
@@ -188,7 +185,7 @@ class UpdateCacheMiddleware(object):
         if result is False:
             LOGGER.error(
                 "Django-fancy-cache failed to save using CAS after %s tries.",
-                tries
+                tries,
             )
         return result
 

--- a/fancy_cache/utils.py
+++ b/fancy_cache/utils.py
@@ -1,5 +1,28 @@
+import datetime
 import hashlib
+import typing
+
+from django.conf import settings
+
+from fancy_cache.constants import LONG_TIME, REMEMBERED_URLS_KEY
+
+CACHE_N_DAYS = getattr(settings, "FANCY_CACHE_N_DAYS", None)
 
 
-def md5(x):
+def md5(x) -> str:
     return hashlib.md5(x.encode("utf-8")).hexdigest()
+
+
+def get_fancy_cache_keys_and_duration() -> typing.Tuple[typing.List[str], int]:
+    cache_keys = []
+    if CACHE_N_DAYS:
+        days = CACHE_N_DAYS
+        duration = days * 60 * 60 * 24
+        while days > 0:
+            key = f"fancy-cache-{datetime.date.today().isoformat()}"
+            cache_keys.append(key)
+            days -= 1
+    else:
+        cache_keys.append(REMEMBERED_URLS_KEY)
+        duration = LONG_TIME
+    return cache_keys, duration

--- a/fancy_tests/tests/test_command.py
+++ b/fancy_tests/tests/test_command.py
@@ -4,7 +4,7 @@ from django.core.cache import cache
 from django.core.management import call_command
 from django.test import TestCase
 from io import StringIO
-from fancy_cache.middleware import REMEMBERED_URLS_KEY
+from fancy_cache.constants import REMEMBERED_URLS_KEY
 
 
 class TestBaseCommand(TestCase):

--- a/fancy_tests/tests/test_memory.py
+++ b/fancy_tests/tests/test_memory.py
@@ -3,7 +3,7 @@ import unittest
 from nose.tools import eq_, ok_
 from django.core.cache import cache
 
-from fancy_cache.middleware import REMEMBERED_URLS_KEY
+from fancy_cache.constants import REMEMBERED_URLS_KEY
 from fancy_cache.memory import find_urls
 
 


### PR DESCRIPTION
@peterbe this is a WIP PR aiming to fix #36. The basic gist is that we have an optional setting, `FANCY_CACHE_N_DAYS`, which limits the number of days that we cache the dict.

If `FANCY_CACHE_N_DAYS` is set, we use a new cache key each calendar date: `fancy-urls-2020-01-28`, `fancy-urls-2020-01-29`, etc. Each of these keys is saved for a `duration` of N days.

When pulling the cache, we use the `fancy_cache.utils.get_remembered_urls` function that creates the equivalent of the current `REMEMBERED_URLS_KEY` dict by merging N of the "daily" cache dicts.

When deleting a key from the cache, we check each of the N dicts and make sure the key is deleted from each.

When saving to the cache, we simply add the entry to the current day's cache entry. This means that cache entries could be duplicated each day, but this isn't a big deal as we're automatically "dropping" old cache entries after N days (i.e., `duration` mentioned above).

I also added a few MyPy type hints to aid in programming and moved constants to their own file; let me know if making a separate PR for those changes would help simplify this one if it's too unwieldy to review.

Would love any thoughts or feedback you have on the approach! Thanks again for your tremendous code reviews, and for maintaining this repo. I really appreciate it.