### PR TITLE
Write a test for Django's DummyBackend.

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           python-version: '3.x'
       - name: install black
-        run: pip install black==21.9b0
+        run: pip install black==22.3.0
       - name: Black
         run: black . --check

--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ Changelog
 
 1.2.1
     * Bugfix: conflict between the DummyCache backend when 
-      `FANCY_USE_MEMCACHED_CHECK_AND_SET` is `True`
+      ``FANCY_USE_MEMCACHED_CHECK_AND_SET`` is ``True``
 
 1.2.0
     * Restructure the remembered_urls cache dict to clean up stale entries

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,10 @@ Or to run it without ``tox`` you can simply run::
 Changelog
 ---------
 
+1.2.1
+    * Bugfix: conflict between the DummyCache backend when 
+      `FANCY_USE_MEMCACHED_CHECK_AND_SET` is `True`
+
 1.2.0
     * Restructure the remembered_urls cache dict to clean up stale entries
     * Update FancyCacheMiddleware to match latest Django CacheMiddlware

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"django-fancy-cache"
-copyright = u"2013, Peter Bengtsson"
+project = "django-fancy-cache"
+copyright = "2013, Peter Bengtsson"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -184,8 +184,8 @@ latex_documents = [
     (
         "index",
         "django-fancy-cache.tex",
-        u"django-fancy-cache Documentation",
-        u"Peter Bengtsson",
+        "django-fancy-cache Documentation",
+        "Peter Bengtsson",
         "manual",
     ),
 ]
@@ -219,8 +219,8 @@ man_pages = [
     (
         "index",
         "django-fancy-cache",
-        u"django-fancy-cache Documentation",
-        [u"Peter Bengtsson"],
+        "django-fancy-cache Documentation",
+        ["Peter Bengtsson"],
         1,
     )
 ]
@@ -238,8 +238,8 @@ texinfo_documents = [
     (
         "index",
         "django-fancy-cache",
-        u"django-fancy-cache Documentation",
-        u"Peter Bengtsson",
+        "django-fancy-cache Documentation",
+        "Peter Bengtsson",
         "django-fancy-cache",
         "One line description of project.",
         "Miscellaneous",

--- a/fancy_cache/__init__.py
+++ b/fancy_cache/__init__.py
@@ -1,3 +1,3 @@
 from .cache_page import cache_page  # NOQA
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/fancy_cache/cache_page.py
+++ b/fancy_cache/cache_page.py
@@ -6,7 +6,11 @@ from .middleware import FancyCacheMiddleware
 
 
 def cache_page(
-    timeout: typing.Optional[float], *, cache=None, key_prefix=None, **kwargs
+    timeout: typing.Optional[float],
+    *,
+    cache: str = None,
+    key_prefix: str = None,
+    **kwargs
 ) -> typing.Callable:
     return decorator_from_middleware_with_args(FancyCacheMiddleware)(
         page_timeout=timeout, cache_alias=cache, key_prefix=key_prefix, **kwargs

--- a/fancy_cache/memory.py
+++ b/fancy_cache/memory.py
@@ -97,7 +97,10 @@ def delete_keys_cas(keys_to_delete: typing.List[str]) -> bool:
     result = False
     tries = 0
     while result is False and tries < 100:
-        remembered_urls, cas_token = cache._cache.gets(REMEMBERED_URLS_KEY)
+        try:
+            remembered_urls, cas_token = cache._cache.gets(REMEMBERED_URLS_KEY)
+        except AttributeError:
+            return False
         if remembered_urls is None:
             return False
         remembered_urls = delete_keys(keys_to_delete, remembered_urls)

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -8,7 +8,7 @@ import time
 import typing
 
 from django.conf import settings
-from django.core.cache import DEFAULT_CACHE_ALIAS
+from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.middleware.cache import (
     FetchFromCacheMiddleware,
     UpdateCacheMiddleware,
@@ -376,6 +376,7 @@ class FancyCacheMiddleware(
             if cache_alias is None:
                 cache_alias = DEFAULT_CACHE_ALIAS
             self.cache_alias = cache_alias
+            self.cache = caches[self.cache_alias]
         except KeyError:
             pass
 

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -196,9 +196,12 @@ class FancyUpdateCacheMiddleware(UpdateCacheMiddleware):
         result = False
         tries = 0  # Make sure an unexpected error doesn't cause a loop
         while result is False and tries <= 100:
-            remembered_urls, cas_token = self.cache._cache.gets(
-                REMEMBERED_URLS_KEY
-            )
+            try:
+                remembered_urls, cas_token = self.cache._cache.gets(
+                    REMEMBERED_URLS_KEY
+                )
+            except AttributeError:
+                return False
 
             if remembered_urls is None:
                 # No cache entry; set the cache using `cache.set`.

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -376,6 +376,14 @@ class FancyCacheMiddleware(
             if cache_alias is None:
                 cache_alias = DEFAULT_CACHE_ALIAS
             self.cache_alias = cache_alias
+            # TODO: Likely this will cause a conflict with this commit
+            # in Django 4.1+:
+            # https://github.com/django/django/commit/3ff7b15bb79f2ee5b7af245c55ae14546243bb77
+            # The commit uses a @property decorator to set self.cache
+            # instead of setting it directly as we do in the line below.
+            # We can likely solve this by simply removing this line,
+            # but will need to make sure that the library still works for
+            # older versions of Django that use this `self.cache =` method.
             self.cache = caches[self.cache_alias]
         except KeyError:
             pass

--- a/fancy_tests/tests/settings.py
+++ b/fancy_tests/tests/settings.py
@@ -22,6 +22,10 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "unique-snowflake",
     },
+    "dummy_backend": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "LOCATION": "unique-snowflake",
+    },
 }
 
 INSTALLED_APPS = [

--- a/fancy_tests/tests/test_views.py
+++ b/fancy_tests/tests/test_views.py
@@ -219,7 +219,7 @@ class TestViews(unittest.TestCase):
 
     def test_remember_stats_all_urls_with_never_cache_decorator(self):
         request = self.factory.get("/anything")
-        response = views.home8(request)
+        response = views.home9(request)
         eq_(response.status_code, 200)
 
         # now ask the memory thing
@@ -237,7 +237,7 @@ class TestViews(unittest.TestCase):
         ok_(timeout > int(time.time()))
 
         # second time
-        response = views.home8(request)
+        response = views.home9(request)
         eq_(response.status_code, 200)
         (match,) = find_urls(urls=["/anything"])
         eq_(match[0], "/anything")
@@ -292,6 +292,25 @@ class TestViews(unittest.TestCase):
 
         # clear second cache backend
         caches["second_backend"].clear()
+        response = views.home7(request)
+        eq_(response.status_code, 200)
+        random_string_2 = re.findall(
+            "Random:(\w+)", response.content.decode("utf8")
+        )[0]
+        ok_(random_string_1 != random_string_2)
+
+    def test_cache_dummy_backend(self):
+        request = self.factory.get("/anything")
+
+        response = views.home8(request)
+        eq_(response.status_code, 200)
+        ok_(re.findall("Random:\w+", response.content.decode("utf8")))
+        random_string_1 = re.findall(
+            "Random:(\w+)", response.content.decode("utf8")
+        )[0]
+
+        # clear second cache backend
+        caches["dummy_backend"].clear()
         response = views.home7(request)
         eq_(response.status_code, 200)
         random_string_2 = re.findall(

--- a/fancy_tests/tests/test_views.py
+++ b/fancy_tests/tests/test_views.py
@@ -311,7 +311,7 @@ class TestViews(unittest.TestCase):
 
         # clear second cache backend
         caches["dummy_backend"].clear()
-        response = views.home7(request)
+        response = views.home8(request)
         eq_(response.status_code, 200)
         random_string_2 = re.findall(
             "Random:(\w+)", response.content.decode("utf8")

--- a/fancy_tests/tests/test_views.py
+++ b/fancy_tests/tests/test_views.py
@@ -300,6 +300,9 @@ class TestViews(unittest.TestCase):
         ok_(random_string_1 != random_string_2)
 
     def test_cache_dummy_backend(self):
+        """
+        Test that the Dummy cache backend works as expected by not caching.
+        """
         request = self.factory.get("/anything")
 
         response = views.home8(request)
@@ -309,11 +312,13 @@ class TestViews(unittest.TestCase):
             "Random:(\w+)", response.content.decode("utf8")
         )[0]
 
-        # clear second cache backend
-        caches["dummy_backend"].clear()
         response = views.home8(request)
         eq_(response.status_code, 200)
         random_string_2 = re.findall(
             "Random:(\w+)", response.content.decode("utf8")
         )[0]
         ok_(random_string_1 != random_string_2)
+
+        # Make sure clearing the dummy cache doesn't raise an error,
+        # even though it should do nothing.
+        caches["dummy_backend"].clear()

--- a/fancy_tests/tests/views.py
+++ b/fancy_tests/tests/views.py
@@ -64,7 +64,12 @@ def home7(request):
     return _view(request)
 
 
+@cache_page(60, cache="dummy_backend")
+def home8(request):
+    return _view(request)
+
+
 @never_cache
 @cache_page(60, remember_stats_all_urls=True, remember_all_urls=True)
-def home8(request):
+def home9(request):
     return _view(request)

--- a/fancy_tests/tests/views.py
+++ b/fancy_tests/tests/views.py
@@ -64,7 +64,7 @@ def home7(request):
     return _view(request)
 
 
-@cache_page(60, cache="dummy_backend")
+@cache_page(60, cache="dummy_backend", remember_all_urls=True)
 def home8(request):
     return _view(request)
 


### PR DESCRIPTION
Fixes #15.

@peterbe there's a tiny bug in the latest version which is that one can't override a test to use DummyCache when FANCY_USE_MEMCACHED_CHECK_AND_SET is True.

I created this test to verify that fancy cache works as expected with `DummyCache` but for whatever reason it appears that the view under test is still being cached. I'm not sure whether it's a testing issue or an issue that the `cache` setting on the decorator isn't working as expected, or something else.

Putting this here as a draft PR and will come back to it later! If you have any ideas feel free to share, but not urgent at all.