### PR TITLE
Bugfix/initial compressed urls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,10 @@ Or to run it without ``tox`` you can simply run::
 Changelog
 ---------
 
+1.3.1
+    * Fix a bug whereby ``FANCY_COMPRESS_REMEMBERED_URLS`` setting
+      raises a TypeError upon first implementation.
+
 1.3.0
     * Enable ``FANCY_COMPRESS_REMEMBERED_URLS`` setting to compress
       ``remembered_urls`` dictionary when ``FANCY_REMEMBER_ALL_URLS``

--- a/fancy_cache/__init__.py
+++ b/fancy_cache/__init__.py
@@ -1,3 +1,3 @@
 from .cache_page import cache_page  # NOQA
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/fancy_cache/memory.py
+++ b/fancy_cache/memory.py
@@ -53,7 +53,8 @@ def find_urls(
     else:
         remembered_urls = cache.get(REMEMBERED_URLS_KEY, {})
     if COMPRESS_REMEMBERED_URLS:
-        remembered_urls = json.loads(zlib.decompress(remembered_urls).decode())
+        if not isinstance(remembered_urls, dict):
+            remembered_urls = json.loads(zlib.decompress(remembered_urls).decode())
     keys_to_delete = []
     if urls:
         regexes = _urls_to_regexes(urls)
@@ -110,9 +111,10 @@ def find_urls(
 
         remembered_urls = cache.get(REMEMBERED_URLS_KEY, {})
         if COMPRESS_REMEMBERED_URLS:
-            remembered_urls = json.loads(
-                zlib.decompress(remembered_urls).decode()
-            )
+            if not isinstance(remembered_urls, dict):
+                remembered_urls = json.loads(
+                    zlib.decompress(remembered_urls).decode()
+                )
         remembered_urls = delete_keys(keys_to_delete, remembered_urls)
         if COMPRESS_REMEMBERED_URLS:
             remembered_urls = zlib.compress(
@@ -130,9 +132,10 @@ def delete_keys_cas(keys_to_delete: typing.List[str]) -> bool:
             return False
 
         if COMPRESS_REMEMBERED_URLS:
-            remembered_urls = json.loads(
-                zlib.decompress(remembered_urls).decode()
-            )
+            if not isinstance(remembered_urls, dict):
+                remembered_urls = json.loads(
+                    zlib.decompress(remembered_urls).decode()
+                )
 
         remembered_urls = delete_keys(keys_to_delete, remembered_urls)
         if COMPRESS_REMEMBERED_URLS:

--- a/fancy_cache/memory.py
+++ b/fancy_cache/memory.py
@@ -54,7 +54,9 @@ def find_urls(
         remembered_urls = cache.get(REMEMBERED_URLS_KEY, {})
     if COMPRESS_REMEMBERED_URLS:
         if not isinstance(remembered_urls, dict):
-            remembered_urls = json.loads(zlib.decompress(remembered_urls).decode())
+            remembered_urls = json.loads(
+                zlib.decompress(remembered_urls).decode()
+            )
     keys_to_delete = []
     if urls:
         regexes = _urls_to_regexes(urls)

--- a/fancy_cache/middleware.py
+++ b/fancy_cache/middleware.py
@@ -207,9 +207,10 @@ class FancyUpdateCacheMiddleware(UpdateCacheMiddleware):
 
         remembered_urls = self.cache.get(REMEMBERED_URLS_KEY, {})
         if COMPRESS_REMEMBERED_URLS:
-            remembered_urls = json.loads(
-                zlib.decompress(remembered_urls).decode()
-            )
+            if not isinstance(remembered_urls, dict):
+                remembered_urls = json.loads(
+                    zlib.decompress(remembered_urls).decode()
+                )
         remembered_urls = filter_remembered_urls(remembered_urls)
         remembered_urls[url] = (cache_key, expiration_time)
         if COMPRESS_REMEMBERED_URLS:
@@ -238,9 +239,10 @@ class FancyUpdateCacheMiddleware(UpdateCacheMiddleware):
                 return False
 
             if COMPRESS_REMEMBERED_URLS:
-                remembered_urls = json.loads(
-                    zlib.decompress(remembered_urls).decode()
-                )
+                if not isinstance(remembered_urls, dict):
+                    remembered_urls = json.loads(
+                        zlib.decompress(remembered_urls).decode()
+                    )
 
             remembered_urls = filter_remembered_urls(remembered_urls)
 

--- a/fancy_tests/tests/test_memory.py
+++ b/fancy_tests/tests/test_memory.py
@@ -57,6 +57,23 @@ class TestMemory(unittest.TestCase):
         found = list(find_urls([]))
         eq_(len(found), 0)
 
+    @mock.patch("fancy_cache.memory.COMPRESS_REMEMBERED_URLS", True)
+    def test_find_and_purge_all_urls_with_zlib_compression_first_time(self):
+        """
+        When enabling zlib compression, the existing REMEMBERED_URLS
+        will not be compressed yet. This test ensures that the transition to
+        compressed REMEMBERED_URLS is seamless.
+        """
+        remembered_urls = cache.get(REMEMBERED_URLS_KEY)
+        cache.set(REMEMBERED_URLS_KEY, remembered_urls, 5)
+        found = list(find_urls([], purge=True))
+        eq_(len(found), 4)
+        for key, value in self.urls.items():
+            pair = (key, value[0], None)
+            ok_(pair in found)
+        found = list(find_urls([]))
+        eq_(len(found), 0)
+
     def test_find_one_url(self):
         found = list(find_urls(["/page1.html"]))
         eq_(len(found), 1)


### PR DESCRIPTION
@peterbe this PR fixes a bug whereby implementing FANCY_COMPRESS_REMEMBERED_URLS for the first time inadvertently tries to decompress an object that wasn't compressed.

I've also bumped the version to 1.3.1.

Thanks for taking a look!